### PR TITLE
missing propagate down

### DIFF
--- a/src/caffe/test/test_multibox_loss_layer.cpp
+++ b/src/caffe/test/test_multibox_loss_layer.cpp
@@ -322,6 +322,7 @@ TYPED_TEST(MultiBoxLossLayerTest, TestLocGradient) {
   typedef typename TypeParam::Dtype Dtype;
   LayerParameter layer_param;
   layer_param.add_propagate_down(true);
+  layer_param.add_propagate_down(false);
   LossParameter* loss_param = layer_param.mutable_loss_param();
   MultiBoxLossParameter* multibox_loss_param =
       layer_param.mutable_multibox_loss_param();


### PR DESCRIPTION
Doesn't complain unless compiling without optimization flags.

propagate_down should have length 2.