### PR TITLE
a little change on SatisfySampleConstraint

### DIFF
--- a/src/caffe/util/sampler.cpp
+++ b/src/caffe/util/sampler.cpp
@@ -76,6 +76,9 @@ bool SatisfySampleConstraint(const NormalizedBBox& sampled_bbox,
       }
       found = true;
     }
+    if (found) {
+      return true;
+    }
   }
   return found;
 }


### PR DESCRIPTION
Avoid unnecessary computation once found flag equals true