### PR TITLE
use mining_type

### DIFF
--- a/examples/ssd/ssd_pascal_resnet.py
+++ b/examples/ssd/ssd_pascal_resnet.py
@@ -225,6 +225,7 @@ normalization_mode = P.Loss.VALID
 code_type = P.PriorBox.CENTER_SIZE
 neg_pos_ratio = 3.
 loc_weight = (neg_pos_ratio + 1.) / 4.
+mining_type = P.MultiBoxLoss.MAX_NEGATIVE
 multibox_loss_param = {
     'loc_loss_type': P.MultiBoxLoss.SMOOTH_L1,
     'conf_loss_type': P.MultiBoxLoss.SOFTMAX,
@@ -236,7 +237,7 @@ multibox_loss_param = {
     'use_prior_for_matching': True,
     'background_label_id': background_label_id,
     'use_difficult_gt': train_on_diff_gt,
-    'do_neg_mining': True,
+    'mining_type': mining_type,
     'neg_pos_ratio': neg_pos_ratio,
     'neg_overlap': 0.5,
     'code_type': code_type,


### PR DESCRIPTION
do_neg_mining is deprecated. 
mining_type = P.MultiBoxLoss.MAX_NEGATIVE used consistently in all other SSD feature extractors, so should be done for resnet as well.