### PR TITLE
Make sure bbox_width & bbox_height <= 1.0 or caffe_rng_uniform will get a error on some devices

### DIFF
--- a/src/caffe/util/sampler.cpp
+++ b/src/caffe/util/sampler.cpp
@@ -106,6 +106,12 @@ void SampleBBox(const Sampler& sampler, NormalizedBBox* sampled_bbox) {
   float bbox_width = scale * sqrt(aspect_ratio);
   float bbox_height = scale / sqrt(aspect_ratio);
 
+  // Make sure bbox_width & bbox_height <= 1.0
+  // When 0.f > 1 - bbox_width caffe_rng_uniform will get
+  // a error on some devices
+  bbox_width = bbox_width >= 0? 1.0f : bbox_width;
+  bbox_height = bbox_height >= 0? 1.0f : bbox_height;
+
   // Figure out top left coordinates.
   float w_off, h_off;
   caffe_rng_uniform(1, 0.f, 1 - bbox_width, &w_off);

--- a/src/caffe/util/sampler.cpp
+++ b/src/caffe/util/sampler.cpp
@@ -109,8 +109,8 @@ void SampleBBox(const Sampler& sampler, NormalizedBBox* sampled_bbox) {
   // Make sure bbox_width & bbox_height <= 1.0
   // When 0.f > 1 - bbox_width caffe_rng_uniform will get
   // a error on some devices
-  bbox_width = bbox_width >= 0? 1.0f : bbox_width;
-  bbox_height = bbox_height >= 0? 1.0f : bbox_height;
+  bbox_width = bbox_width >= 1.0? 1.0f : bbox_width;
+  bbox_height = bbox_height >= 1.0? 1.0f : bbox_height;
 
   // Figure out top left coordinates.
   float w_off, h_off;


### PR DESCRIPTION
in sampler.cpp SampleBBox function, bbox_width & bbox_height not aways <=1.0f on some devices